### PR TITLE
doc/Installation: Add install commands for non-Debian distributions

### DIFF
--- a/doc/Installation.adoc
+++ b/doc/Installation.adoc
@@ -65,6 +65,15 @@ user@val:~$ cd yubikey-val
 user@val:~/yubikey-val$ sudo make install
 ----
 
+Depending on your distribution, the group of Apache (or the HTTP server) might
+be different from `www-data`, used in Debian and Ubuntu. On Red Hat, Fedora or
+CentOS the group is `apache` and in SUSE it is `www`.
+
+[source, sh]
+----
+user@val:~/yubikey-val: sudo make install wwwgroup=apache
+----
+
 The rest of this documentation will assume you have YK-VAL available
 in the default installation targets.  You can override the paths, see
 the Makefile.


### PR DESCRIPTION
Running `sudo make install` on non-Debian distributions fails, as the
group of the Apache HTTP server are named differently. Therefore, update
the documentation. The group name for SUSE is taken from the [OTRS
manual][1].

[1]: https://otrs.github.io/doc/manual/admin/4.0/de/html/manual-installation-of-otrs.html