### PR TITLE
doc/Installation: Grant insert and update rights to `ykval_verifier`

### DIFF
--- a/doc/Installation.adoc
+++ b/doc/Installation.adoc
@@ -134,7 +134,7 @@ normally called 'ykval_verifier':
 user@val:~$ mysql --silent ykval
 mysql> CREATE USER 'ykval_verifier'@'localhost'; \
 GRANT SELECT,INSERT,UPDATE(modified, yk_counter, yk_low, yk_high, yk_use, nonce) ON ykval.yubikeys TO 'ykval_verifier'@'localhost'; \
-GRANT SELECT(id, secret, active) ON ykval.clients TO 'ykval_verifier'@'localhost'; \
+GRANT SELECT,INSERT,UPDATE(id, secret, active) ON ykval.clients TO 'ykval_verifier'@'localhost'; \
 GRANT SELECT,INSERT,UPDATE,DELETE ON ykval.queue TO 'ykval_verifier'@'localhost'; \
 SET PASSWORD FOR 'ykval_verifier'@'localhost' = PASSWORD('yourpassword'); \
 FLUSH PRIVILEGES;
@@ -171,7 +171,7 @@ normally called 'ykval_verifier':
 postgres@val:~$ psql ykval -q
 ykval=# CREATE USER ykval_verifier PASSWORD 'yourpassword';
 ykval=# GRANT SELECT,INSERT,UPDATE ON yubikeys TO ykval_verifier;
-ykval=# GRANT SELECT ON clients TO ykval_verifier;
+ykval=# GRANT SELECT,INSERT,UPDATE ON clients TO ykval_verifier;
 ykval=# GRANT SELECT, INSERT, UPDATE, DELETE ON queue TO ykval_verifier;
 ykval=# \q
 postgres@val:~$


### PR DESCRIPTION
Currently, when following the installation instructions, the scripts
adding clients to the database don’t work as the user `ykval_verifier`
does not have any insert rights for the table `clients`.

```
LOG_DEBUG:ykval-gen-clients:db:DB query is:SELECT id FROM clients ORDER BY id DESC LIMIT 1
LOG_DEBUG:ykval-gen-clients:db:DB query is: INSERT INTO clients (id,active,created,secret,email,notes,otp) VALUES ('1', '1', '1404359826','XXXXXXXXXXXXXXXXXXXXXXXX =','','','')
LOG_INFO:ykval-gen-clients:db:Database query error: Array ( [0] => 42000 [1] => 1142 [2] => INSERT command denied to user 'ykval_verifier'@'localhost' for table 'clients' )
LOG_ERR:ykval-gen-clients:Failed to insert new client with query INSERT INTO clients (id,active,created,secret,email,notes,otp) VALUES ('1', '1', '1404359826’,’XXXXXXXXXXXXXXXXXXXXXXXX=','','','')
Failed to insert new client with query INSERT INTO clients (id,active,created,secret,email,notes,otp) VALUES ('1', '1', '1404359826','XXXXXXXXXXXXXXXXXXXXXXXX =','','','')`
```

Therefore, update the documentation, to also grant the user
`ykval_verifier` the rights to insert and update records into the table
`clients`. No delete rights are granted, because there is an `active`
column, which should probably used over deletion of clients.

Note, the original idea was probably to use two database users. One for
inserting and updating data, and one for querying/validating it. As,
nothing is written about this though, use the existing/recommended user
for both things.

Fixes: #20 (ykval_verifier SQL user doesn't have permission to INSERT
INTO clients, breaks ykval-gen-clients)