### PR TITLE
Possible oops with sync pools

### DIFF
--- a/ykval-cron
+++ b/ykval-cron
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Something to keep ykval-queue going
+# run this in cron
+# restarts if necessary
+
+RUNAS=ykval
+
+function start
+{
+    su -s /bin/bash -c '/usr/sbin/ykval-queue &>/dev/null &' - ${RUNAS}
+    exit 0
+}
+
+
+FOUND=$( ps -C ykval-queue | wc -l )
+
+if [[ ${FOUND} -lt 2 ]]; then
+  start
+fi
+
+exit 0

--- a/ykval-verify.php
+++ b/ykval-verify.php
@@ -378,9 +378,13 @@ if (!$sync->queue($otpParams, $localParams))
 
 $nr_servers = $sync->getNumberOfServers();
 $req_answers = ceil($nr_servers * $sl / 100.0);
-if ($req_answers > 0)
+// try syncing anyway
+if ($nr_servers > 0)
 {
-	$syncres = $sync->sync($req_answers, $timeout);
+	// we need to attempt syncing with all servers, since one may
+	// return replayed counters. Using $req_answers means such a server
+	// may get ignored.
+	$syncres = $sync->sync($nr_servers, $timeout);
 	$nr_answers = $sync->getNumberOfAnswers();
 	$nr_valid_answers = $sync->getNumberOfValidAnswers();
 	$sl_success_rate = floor(100.0 * $nr_valid_answers / $nr_servers);
@@ -405,16 +409,26 @@ $myLog->log(LOG_INFO, '', array(
 
 if ($syncres == False)
 {
-	/* sync returned false, indicating that
-		either at least 1 answer marked OTP as invalid or
-		there were not enough answers */
-	$myLog->log(LOG_WARNING, 'Sync failed');
+	/* sync returned false, indicating that not all servers returned valid answers;
+		some may have returned NO answer (host down...).  Sort this out here, 
+		it's not the end of the world yet! */
 
-	if ($nr_valid_answers != $nr_answers)
+	if ($nr_answers != $nr_valid_answers)
+	{
+		/* at least 1 answers marked OTP as invalid */
+		$myLog->log(LOG_WARNING, 'Sync failed');
 		sendResp(S_REPLAYED_OTP, $myLog, $apiKey, $extra);
+	}
 
-	$extra['sl'] = $sl_success_rate;
-	sendResp(S_NOT_ENOUGH_ANSWERS, $myLog, $apiKey, $extra);
+	if ($nr_valid_answers < $req_answers)
+	{
+		/* not enough valid answers */
+		$myLog->log(LOG_WARNING, 'Sync failed');
+
+		$extra['sl'] = $sl_success_rate;
+		sendResp(S_NOT_ENOUGH_ANSWERS, $myLog, $apiKey, $extra);
+	}
+
 }
 
 if ($otpParams['yk_counter'] == $localParams['yk_counter'] && $otpParams['yk_use'] > $localParams['yk_use'])


### PR DESCRIPTION
Hi, I found what appears to be an error in the verification code when operating with a sync pool.
In short, it looks like some peers may get ignored, which is bad if the ignored peers happen to return replayed counter values.

I've implemented what appears to be a fix, and enabled reasonable behavior for two-peer pools (where authentication doesn't break because one of the two peers is down).

Also added an example cron script to keep ykval-queue running.
