### PR TITLE
Fix documentation to reflect correct GRANT privileges required

### DIFF
--- a/doc/Installation.adoc
+++ b/doc/Installation.adoc
@@ -133,7 +133,8 @@ normally called 'ykval_verifier':
 ----
 user@val:~$ mysql --silent ykval
 mysql> CREATE USER 'ykval_verifier'@'localhost'; \
-GRANT SELECT,INSERT,UPDATE(modified, yk_counter, yk_low, yk_high, yk_use, nonce) ON ykval.yubikeys TO 'ykval_verifier'@'localhost'; \
+GRANT SELECT,INSERT(active, created, yk_publicname, notes, modified, yk_counter, yk_low, yk_high, yk_use, nonce) ON ykval.yubikeys TO 'ykval_verifier'@'localhost'; \
+GRANT UPDATE(modified, yk_counter, yk_low, yk_high, yk_use, nonce) ON ykval.yubikeys TO 'ykval_verifier'@'localhost'; \
 GRANT SELECT,INSERT,UPDATE(id, secret, active) ON ykval.clients TO 'ykval_verifier'@'localhost'; \
 GRANT SELECT,INSERT,UPDATE,DELETE ON ykval.queue TO 'ykval_verifier'@'localhost'; \
 SET PASSWORD FOR 'ykval_verifier'@'localhost' = PASSWORD('yourpassword'); \


### PR DESCRIPTION
It seems some columns are missing from the GRANT statement in the documentation.  This change adds active, created, yk_publicname and notes for SELECT and INSERT privileges.

Otherwise, you'll get errors like this in the logs:

Database query error: Array ( ...  INSERT command denied to user 'ykval_verifier'@'localhost' for column 'notes' in table 'yubikeys' )